### PR TITLE
SPORTS-24 Add an API to delete a tournament.

### DIFF
--- a/backend/src/controllers/tournamentController.ts
+++ b/backend/src/controllers/tournamentController.ts
@@ -84,3 +84,24 @@ export async function update(req: Request, res: Response, next: NextFunction) {
     next(error);
   }
 }
+
+/**
+ * Delete or remove a new tournament.
+ *
+ * @export
+ * @param {Request} req
+ * @param {Response} res
+ * @param {NextFunction} next
+ */
+export async function remove(req: Request, res: Response, next: NextFunction) {
+  try {
+    const tournamentId = req.params.id;
+    const tournament = await TournamentService.remove(tournamentId);
+
+    res.status(HttpStatus.OK).json({
+      data: tournament
+    });
+  } catch (error) {
+    next(error);
+  }
+}

--- a/backend/src/controllers/tournamentController.ts
+++ b/backend/src/controllers/tournamentController.ts
@@ -63,3 +63,24 @@ export async function create(req: Request, res: Response, next: NextFunction) {
     next(error);
   }
 }
+
+/**
+ * Update a tournament information.
+ *
+ * @export
+ * @param {Request} req
+ * @param {Response} res
+ * @param {NextFunction} next
+ */
+export async function update(req: Request, res: Response, next: NextFunction) {
+  try {
+    const tournamentId = req.params.id;
+    const tournament = await TournamentService.update(tournamentId, req.body);
+
+    res.status(HttpStatus.OK).json({
+      data: tournament
+    });
+  } catch (error) {
+    next(error);
+  }
+}

--- a/backend/src/middlewares/v1/tournamentMiddlewares.ts
+++ b/backend/src/middlewares/v1/tournamentMiddlewares.ts
@@ -6,6 +6,7 @@ import * as URLParamsValidator from '../../validators/paramsValidator';
 import * as TournamentValidator from '../../validators/tournamentValidator';
 
 router.get('/:id', URLParamsValidator.validateURLParams);
+router.delete('/:id', URLParamsValidator.validateURLParams);
 router.post('/', TournamentValidator.validateTournamentSchema);
 router.put('/:id', URLParamsValidator.validateURLParams, TournamentValidator.validateTournamentSchema);
 

--- a/backend/src/middlewares/v1/tournamentMiddlewares.ts
+++ b/backend/src/middlewares/v1/tournamentMiddlewares.ts
@@ -7,5 +7,6 @@ import * as TournamentValidator from '../../validators/tournamentValidator';
 
 router.get('/:id', URLParamsValidator.validateURLParams);
 router.post('/', TournamentValidator.validateTournamentSchema);
+router.put('/:id', URLParamsValidator.validateURLParams, TournamentValidator.validateTournamentSchema);
 
 export default router;

--- a/backend/src/routes/v1/tournamentRoutes.ts
+++ b/backend/src/routes/v1/tournamentRoutes.ts
@@ -9,5 +9,6 @@ router.get('/', tournamentController.getAll);
 router.get('/:id', tournamentController.get);
 router.post('/', tournamentController.create);
 router.put('/:id', tournamentController.update);
+router.delete('/:id', tournamentController.remove);
 
 export default router;

--- a/backend/src/routes/v1/tournamentRoutes.ts
+++ b/backend/src/routes/v1/tournamentRoutes.ts
@@ -6,7 +6,8 @@ const router: Router = Router();
 
 // Tournaments
 router.get('/', tournamentController.getAll);
-router.post('/', tournamentController.create);
 router.get('/:id', tournamentController.get);
+router.post('/', tournamentController.create);
+router.put('/:id', tournamentController.update);
 
 export default router;

--- a/backend/src/services/tournamentService.ts
+++ b/backend/src/services/tournamentService.ts
@@ -64,3 +64,32 @@ export async function create(params: object) {
     throw error;
   }
 }
+
+/**
+ * Update a tournament information.
+ *
+ * @export
+ * @param {number} id
+ * @param {object} params
+ * @returns {Tournament}
+ * @throws {NotFoundError|NoRowUpdatedError|error}
+ */
+export async function update(id: number, params: object) {
+  try {
+    const tournament: Tournament = await findById(id);
+
+    if (!tournament) {
+      throw new NotFoundError('Tournament not found.');
+    }
+
+    const updatedTournament = await tournament.save(params, { patch: true });
+
+    if (!updatedTournament) {
+      throw new NoRowUpdatedError('Unable to update the tournament info.');
+    }
+
+    return updatedTournament;
+  } catch (error) {
+    throw error;
+  }
+}

--- a/backend/src/services/tournamentService.ts
+++ b/backend/src/services/tournamentService.ts
@@ -93,3 +93,31 @@ export async function update(id: number, params: object) {
     throw error;
   }
 }
+
+/**
+ * Delete or remove a tournament.
+ *
+ * @export
+ * @param {number} id
+ * @returns {Tournament}
+ * @throws {NotFoundError|NoRowUpdatedError|error}
+ */
+export async function remove(id: number) {
+  try {
+    const tournament: Tournament = await findById(id);
+
+    if (!tournament) {
+      throw new NotFoundError('Tournament not found.');
+    }
+
+    const deletedTournament = await tournament.destroy();
+
+    if (!deletedTournament) {
+      throw new NoRowUpdatedError('Unable to create a new tournament.');
+    }
+
+    return deletedTournament;
+  } catch (error) {
+    throw error;
+  }
+}

--- a/backend/src/services/tournamentService.ts
+++ b/backend/src/services/tournamentService.ts
@@ -101,7 +101,7 @@ export async function update(id: number, params: object) {
  *
  * @export
  * @param {number} id
- * @returns {Tournament}
+ * @returns {object}
  * @throws {NotFoundError|NoRowUpdatedError|error}
  */
 export async function remove(id: number) {
@@ -118,7 +118,9 @@ export async function remove(id: number) {
       throw new NoRowUpdatedError('Unable to create a new tournament.');
     }
 
-    return deletedTournament;
+    return {
+      'message': 'Tournament deleted successfully.'
+    };
   } catch (error) {
     throw error;
   }


### PR DESCRIPTION
- Need to merge #17 before this one :smiley:
- `DELETE /api/v1/tournaments/:id`
- `id` validation
- Examples

```
DELETE http://localhost:5000/api/v1/tournaments/1

{
    "data": {
        "message": "Tournament deleted successfully."
    }
}
```

```
DELETE http://localhost:5000/api/v1/tournaments/45

{
    "error": {
        "code": 404,
        "message": "Tournament not found."
    }
}
```