### PR TITLE
SPORTS-59 Add seeds for round and user_role tables

### DIFF
--- a/backend/src/constants/fixedModelValues.ts
+++ b/backend/src/constants/fixedModelValues.ts
@@ -1,0 +1,43 @@
+export const USER_ROLES = {
+  ADMIN: {
+    id: 1,
+    desc: 'Admin'
+  },
+  USER: {
+    id: 2,
+    desc: 'User'
+  }
+};
+
+export const ROUNDS = {
+  FINAL: {
+    id: 1,
+    name: 'Finale',
+    desc: 'Grand Finale'
+  },
+  SEMI_FINAL: {
+    id: 2,
+    name: 'Semi Final',
+    desc: 'Semi Final'
+  },
+  QUARTER_FINAL: {
+    id: 3,
+    name: 'Quarter Final',
+    desc: 'Quarter Final'
+  },
+  PRE_QUARTER_FINAL: {
+    id: 4,
+    name: 'Pre-Quarter Final',
+    desc: 'Pre-Quarter Final/Round of 16'
+  },
+  ROUND_OF_32: {
+    id: 5,
+    name: 'Round of 32',
+    desc: 'Round of 32'
+  },
+  PLAY_OFFS: {
+    id: 6,
+    name: 'Play Off(s)',
+    desc: 'Play Off(s)'
+  }
+};

--- a/backend/src/constants/tables.ts
+++ b/backend/src/constants/tables.ts
@@ -1,3 +1,5 @@
 export const TABLES = {
+  ROUND: 'round',
+  USER_ROLE: 'user_role',
   TOURNAMENT: 'tournament'
 };

--- a/backend/src/seeds/seed_round_table.ts
+++ b/backend/src/seeds/seed_round_table.ts
@@ -1,0 +1,50 @@
+import * as Knex from 'knex';
+
+import { TABLES } from '../constants/tables';
+import { ROUNDS } from '../constants/fixedModelValues';
+
+/**
+ * @export
+ * @param {Knex} knex
+ * @returns
+ */
+export function seed(knex: Knex) {
+  return knex(TABLES.ROUND)
+    .del()
+    .then(() => {
+      return Promise.all([
+        knex(TABLES.ROUND).insert([
+          {
+            id: ROUNDS.FINAL.id,
+            name: ROUNDS.FINAL.name,
+            desc: ROUNDS.FINAL.desc
+          },
+          {
+            id: ROUNDS.SEMI_FINAL.id,
+            name: ROUNDS.SEMI_FINAL.name,
+            desc: ROUNDS.SEMI_FINAL.desc
+          },
+          {
+            id: ROUNDS.QUARTER_FINAL.id,
+            name: ROUNDS.QUARTER_FINAL.name,
+            desc: ROUNDS.QUARTER_FINAL.desc
+          },
+          {
+            id: ROUNDS.PRE_QUARTER_FINAL.id,
+            name: ROUNDS.PRE_QUARTER_FINAL.name,
+            desc: ROUNDS.PRE_QUARTER_FINAL.desc
+          },
+          {
+            id: ROUNDS.ROUND_OF_32.id,
+            name: ROUNDS.ROUND_OF_32.name,
+            desc: ROUNDS.ROUND_OF_32.desc
+          },
+          {
+            id: ROUNDS.PLAY_OFFS.id,
+            name: ROUNDS.PLAY_OFFS.name,
+            desc: ROUNDS.PLAY_OFFS.desc
+          }
+        ])
+      ]);
+    });
+}

--- a/backend/src/seeds/seed_user_role_table.ts
+++ b/backend/src/seeds/seed_user_role_table.ts
@@ -1,0 +1,28 @@
+import * as Knex from 'knex';
+
+import { TABLES } from '../constants/tables';
+import { USER_ROLES } from '../constants/fixedModelValues';
+
+/**
+ * @export
+ * @param {Knex} knex
+ * @returns
+ */
+export function seed(knex: Knex) {
+  return knex(TABLES.USER_ROLE)
+    .del()
+    .then(() => {
+      return Promise.all([
+        knex(TABLES.USER_ROLE).insert([
+          {
+            id: USER_ROLES.ADMIN.id,
+            desc: USER_ROLES.ADMIN.desc
+          },
+          {
+            id: USER_ROLES.USER.id,
+            desc: USER_ROLES.USER.desc
+          }
+        ])
+      ]);
+    });
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,15 @@ services:
     depends_on:
       sports_db:
         condition: service_healthy
+  sports_db_seed:
+    image: 'node:8-alpine'
+    volumes:
+      - './backend/:/home/sports/backend/'
+    working_dir: /home/sports/backend/
+    command: sh -c 'yarn seed'
+    depends_on:
+      sports_db:
+        condition: service_healthy
   sports_db:
     image: 'postgres:10-alpine'
     restart: always


### PR DESCRIPTION
- Seed data to `round` and `user_role` tables.
- Add a docker-compose service `sport_db_seed` to seed data to the tables.