### PR TITLE
SPORTS-82 Edit production webpack config to load svg images

### DIFF
--- a/frontend/webpack.config.prod.js
+++ b/frontend/webpack.config.prod.js
@@ -42,11 +42,11 @@ module.exports = {
       },
       {
         test: /\.(jpe?g|png|gif|svg)$/i,
-        use: 'file-loader?name=[name].[ext]&publicPath=/images/&outputPath=/'
+        use: ['file-loader']
       },
       {
-        test: /\.(ttf|eot|svg|woff(2)?)(\?[a-z0-9=&.]+)?$/,
-        use: 'file-loader?name=[name].[ext]&publicPath=/fonts/&outputPath=/'
+        test: /\.(ttf|eot|woff(2)?)(\?[a-z0-9=&.]+)?$/,
+        use: ['file-loader']
       }
     ]
   },


### PR DESCRIPTION
- Remove duplicate file loader for svg files.
- Use `['file-loader']` to load files instead of absolute path.